### PR TITLE
Use print as a function in SConstruct build file for Py3 compatibility.

### DIFF
--- a/benejson/SConscript
+++ b/benejson/SConscript
@@ -9,11 +9,11 @@ lib_env = lib_env.Clone()
 conf = Configure(lib_env)
 
 if not conf.CheckFunc("stpcpy"):
-	print "Did not find stpcpy(), using bnj local version"
+	print("Did not find stpcpy(), using bnj local version")
 	conf.env.Append(CPPDEFINES = ["-Dstpcpy=bnj_local_stpcpy"])
 
 if not conf.CheckFunc("stpncpy"):
-	print "Did not find stpncpy(), using bnj local version"
+	print("Did not find stpncpy(), using bnj local version")
 	conf.env.Append(CPPDEFINES = ["-Dstpncpy=bnj_local_stpncpy"])
 lib_env = conf.Finish()
 


### PR DESCRIPTION
This allow to run SCons on Python 3