### PR TITLE
SConstruct: use c99

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -9,9 +9,8 @@ mydir = os.getcwd()
 #Set default C++ building flags for both libraries and executables
 default_env = Environment(ENV = os.environ)
 default_env.Append(CPPPATH = [mydir + '/include'])
-default_env.Append(CCFLAGS = ' -Wall -pedantic')
-default_env.Append(CFLAGS = ' -std=c11')
-default_env.Append(CXXFLAGS = ' -std=c++11')
+default_env.Append(CFLAGS = ' -Wall')
+default_env.Append(CFLAGS = ' -std=c99')
 #default_env.Append(CCFLAGS = ' -O2 -fomit-frame-pointer')
 default_env.Append(CCFLAGS = ' -O0 -g')
 


### PR DESCRIPTION
Some older toolchains do not recognize c11 as a valid standard.
Since the code actually builds well with c99, use that instead.

The only two non-standard features used are // comments
and for(int i ...) declarations in C.

Signed-off-by: Alex Suykov <alex.suykov@gmail.com>
[Retrieved from:
https://git.buildroot.net/buildroot/tree/package/benejson/0001-c-std.patch]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>